### PR TITLE
[ENH]: Migrating to PEP 518 (pyproject.toml)

### DIFF
--- a/SERD/SERD.py
+++ b/SERD/SERD.py
@@ -441,12 +441,8 @@ def interface(
             & (atominfo[:, 1] != "N")
             & (atominfo[:, 1] != "O")
         )
-        atominfo = atominfo[
-            mask[0],
-        ]
-        xyzr = xyzr[
-            mask[0],
-        ]
+        atominfo = atominfo[mask[0],]
+        xyzr = xyzr[mask[0],]
 
     # Prepare atominfo
     atominfo = atominfo[:, 0].tolist()

--- a/SERD/__init__.py
+++ b/SERD/__init__.py
@@ -16,9 +16,4 @@ __name__ = "SERD"
 __version__ = "0.2.0"
 __license__ = "GNU GPL-3.0 License"
 
-try:
-    from .SERD import *
-except SyntaxError:
-    pass
-except ModuleNotFoundError:
-    pass
+from .SERD import *

--- a/SERD/__init__.py
+++ b/SERD/__init__.py
@@ -13,7 +13,7 @@ See also
 """
 
 __name__ = "SERD"
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 __license__ = "GNU GPL-3.0 License"
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = [
+    "setuptools>=74.1",
+    "wheel>=0.37.1",
+    "Cython>=0.29",
+    "numpy>=1.21.5",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "SERD"
+description = "A Python package to detect solvent-exposed residues of a target biomolecule."
+readme = { file = "README.rst", content-type = "text/x-rst" }
+requires-python = ">=3.10, <4"
+license = { file = "LICENSE" }
+authors = [
+    { name = "João V. S. Guerra", email = "jvsguerra@gmail.com" },
+    { name = "Gabriel E. Jara" },
+    { name = "José G. C. Pereira" },
+    { name = "Helder V. Ribeiro-Filho" },
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = [
+    "networkx~=3.4.2",
+    "numpy~=2.1.2",
+    "pyKVFinder~=0.7.1",
+    "scipy~=1.14.1",
+]
+dynamic = ["version"]
+keywords = [
+    "structural biology",
+    "proteins",
+    "biomolecular surface",
+    "solvent-exposed residues",
+]
+
+[project.urls]
+homepage = "https://github.com/jvsguerra/SERD"
+source = "https://github.com/jvsguerra/SERD/"
+issues = "https://github.com/jvsguerra/SERD/issues"
+
+[tool.setuptools]
+packages = ["SERD"]
+include-package-data = true
+py-modules = ["_SERD"]
+ext-modules = [
+    { name = "_SERD", sources = [
+        "C/SERD.i",
+        "C/SERD.c",
+    ], include-dirs = [
+        "/home/jvsguerra/.local/lib/python3.12/site-packages/numpy/core/include",
+        "C",
+    ], extra-compile-args = [
+        "-fopenmp",
+        "-Ofast",
+        "-lm",
+    ], extra-link-args = [
+        "-lgomp",
+    ] },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=74.1",
+    "setuptools>=62.0",
     "wheel>=0.37.1",
     "Cython>=0.29",
     "numpy>=1.21.5",
@@ -46,26 +46,14 @@ keywords = [
 ]
 
 [project.urls]
-homepage = "https://github.com/jvsguerra/SERD"
-source = "https://github.com/jvsguerra/SERD/"
-issues = "https://github.com/jvsguerra/SERD/issues"
+homepage = "https://github.com/LBC-LNBio/SERD"
+source = "https://github.com/LBC-LNBio/SERD/"
+issues = "https://github.com/LBC-LNBio/SERD/issues"
 
 [tool.setuptools]
 packages = ["SERD"]
 include-package-data = true
 py-modules = ["_SERD"]
-ext-modules = [
-    { name = "_SERD", sources = [
-        "C/SERD.i",
-        "C/SERD.c",
-    ], include-dirs = [
-        "/home/jvsguerra/.local/lib/python3.12/site-packages/numpy/core/include",
-        "C",
-    ], extra-compile-args = [
-        "-fopenmp",
-        "-Ofast",
-        "-lm",
-    ], extra-link-args = [
-        "-lgomp",
-    ] },
-]
+
+[tool.setuptools.dynamic]
+version = { attr = "SERD.__version__" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-networkx>=2.8.6
-numpy>=1.23.2
-pyKVFinder>=0.4.2
-scipy>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -1,94 +1,24 @@
-#!/usr/bin/env python
-
-# System imports
 import sys
-import pathlib
-from setuptools import setup, Extension, dist
+from setuptools import Extension, setup
 
-# SERD information
-from SERD import __name__, __version__
 
-# Prepare reqs from requirements.txt
-with open("requirements.txt") as f:
-    reqs = f.read().splitlines()
+class get_numpy_include(object):
+    def __str__(self):
+        import numpy
 
-# Get the long description from the README file
-long_description = (pathlib.Path(__file__).parent.resolve() / "README.rst").read_text(
-    encoding="utf-8"
-)
+        return numpy.get_include()
 
-# Third-party modules - we depend on numpy for everything
-np_req = [req for req in reqs if req.find("numpy") != -1]
-dist.Distribution().fetch_build_eggs(np_req)
-import numpy
 
-# Obtain the numpy include directory.  This logic works across numpy versions.
-try:
-    numpy_include = numpy.get_include()
-except AttributeError:
-    numpy_include = numpy.get_numpy_include()
-
-# Extension modules
-_SERD = Extension(
-    name="_SERD",
-    sources=["C/SERD.i", "C/SERD.c"],
-    include_dirs=[numpy_include, "C"],
-    extra_compile_args=["-fopenmp", "-Ofast", "-lm"],
-    extra_link_args=["-lgomp", "-static"] if sys.platform != 'linux' else ["-lgomp"],
-)
-
-# Setup
 setup(
-    name=__name__,
-    version=__version__,
-    description="A Python package to detect solvent-exposed residues of a target biomolecule.",
-    # This is an optional longer description of your project that represents
-    # the body of text which users will see when they visit PyPI.
-    long_description=long_description,
-    long_description_content_type="text/x-rst",
-    # This field corresponds to the "Home-Page" metadata field:
-    url="https://github.com/jvsguerra/SERD",
-    # Authors information
-    author="João Victor da Silva Guerra, Gabriel Ernesto Jara, José Geraldo de Carvalho Pereira",  # Optional
-    author_email="jvsguerra@gmail.com",
-    # Classifiers help users find your project by categorizing it.
-    classifiers=[  # Optional
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        "Development Status :: 4 - Beta",
-        # Indicate who your project is intended for
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering :: Bio-Informatics",
-        "Topic :: Scientific/Engineering :: Chemistry",
-        # Pick your license as you wish
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate you support Python 3. These classifiers are *not*
-        # checked by 'pip install'. See instead 'python_requires' below.
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3 :: Only",
-    ],
-    # Keywords
-    keywords="structural biology, proteins, biomolecular surface, solvent-exposed residues",
-    # Extension C modules
-    ext_modules=[_SERD],
-    # Python package configuration
-    packages=["SERD"],
-    # Python versions support
-    python_requires=">=3.8, <4",
-    # This field lists other packages that your project depends on to run.
-    install_requires=reqs,
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.
-    include_package_data=True,
-    # List additional URLs that are relevant to your project as a dict.
-    project_urls={  # Optional
-        "Source": "https://github.com/jvsguerra/SERD/",
-        "Issues": "https://github.com/jvsguerra/SERD/issues",
-    },
+    ext_modules=[
+        Extension(
+            name="_SERD",
+            sources=["C/SERD.i", "C/SERD.c"],
+            include_dirs=[get_numpy_include(), "C"],
+            extra_compile_args=["-fopenmp", "-Ofast", "-lm"],
+            extra_link_args=(
+                ["-lgomp", "-static"] if sys.platform != "linux" else ["-lgomp"]
+            ),
+        ),
+    ]
 )


### PR DESCRIPTION
## Major changes
- [x] PEP 518: from `setup.py` to `pyproject.toml`
- [x] Compatibility to Python versions: `3.10`, `3.11` and `3.12`
- [x] Update dependencies (`networkx`, `numpy`, `pyKVFinder`, `scipy`)
- [x] Update build workflow
- [x] Update issue template